### PR TITLE
Using KTP and injecting ViewModelFactory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.google.android.material:material:1.4.0-alpha01'
+    implementation 'com.google.android.material:material:1.4.0-alpha02'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
@@ -81,8 +81,12 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
-    implementation 'com.github.stephanenicolas.toothpick:toothpick-runtime:1.1.3'
-    implementation 'com.github.stephanenicolas.toothpick:smoothie:1.1.3'
-    kapt 'com.github.stephanenicolas.toothpick:toothpick-compiler:1.1.3'
+    // Toothpick and KTP
+    api "com.github.stephanenicolas.toothpick:smoothie-lifecycle-ktp:3.0.2"
+    api "com.github.stephanenicolas.toothpick:ktp:3.1.0"
+    kapt "com.github.stephanenicolas.toothpick:toothpick-compiler:3.1.0"
+    implementation 'com.github.stephanenicolas.toothpick:toothpick-runtime:3.1.0'
+    implementation 'com.github.stephanenicolas.toothpick:smoothie:3.0.2'
+    kapt 'com.github.stephanenicolas.toothpick:toothpick-compiler:3.1.0'
     testImplementation 'com.github.stephanenicolas.toothpick:toothpick-testing:1.1.3'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
 
     <application
+        android:name=".WowpaperApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/pmatuki/wowpapers/WowpaperApplication.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/WowpaperApplication.kt
@@ -1,0 +1,26 @@
+package com.pmatuki.wowpapers
+
+import android.app.Application
+import android.content.Context
+import toothpick.config.Module
+import toothpick.ktp.KTP
+import toothpick.ktp.binding.bind
+
+class WowpaperApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        KTP.openRootScope().openSubScope(APP_SCOPE).installModules(AppModule(this)).inject(this)
+    }
+
+    class AppModule(application: Application) : Module() {
+        init {
+            val context = application.applicationContext
+            bind<Context>().toInstance(context)
+        }
+    }
+
+    companion object {
+        const val APP_SCOPE = "WowpaperApplicationScope"
+    }
+}

--- a/app/src/main/java/com/pmatuki/wowpapers/core/WallpaperService.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/core/WallpaperService.kt
@@ -6,8 +6,10 @@ import android.graphics.drawable.Drawable
 import androidx.core.graphics.drawable.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import toothpick.InjectConstructor
 import java.io.IOException
 
+@InjectConstructor
 class WallpaperService(private val context: Context) {
 
     suspend fun applyWallpaper(imgDrawable: Drawable) : WallpaperApplyResult =

--- a/app/src/main/java/com/pmatuki/wowpapers/remote/WallpaperDataSource.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/remote/WallpaperDataSource.kt
@@ -1,8 +1,10 @@
 package com.pmatuki.wowpapers.remote
 
 import com.pmatuki.wowpapers.remote.api.WallhavenService
+import toothpick.InjectConstructor
 
-class WallpaperDataSource(private val wallhavenService: WallhavenService) {
+@InjectConstructor
+class WallpaperDataSource(val wallhavenService: WallhavenService) {
 
     suspend fun getWallpapers() = wallhavenService.wallApi.searchWallpapers(
         "abstract",

--- a/app/src/main/java/com/pmatuki/wowpapers/remote/api/WallhavenService.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/remote/api/WallhavenService.kt
@@ -5,8 +5,10 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import toothpick.InjectConstructor
 import javax.inject.Inject
 
+@InjectConstructor
 class WallhavenService {
 
     val wallApi: WallhavenApi

--- a/app/src/main/java/com/pmatuki/wowpapers/remote/download/ImageDownloadService.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/remote/download/ImageDownloadService.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import toothpick.InjectConstructor
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
+@InjectConstructor
 class ImageDownloadService(private val context: Context) {
 
     suspend fun performDownload(url: String) : DownloadResult {

--- a/app/src/main/java/com/pmatuki/wowpapers/view/detail/DetailActivity.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/view/detail/DetailActivity.kt
@@ -6,9 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.pmatuki.wowpapers.R
-import com.pmatuki.wowpapers.core.WallpaperService
 import com.pmatuki.wowpapers.databinding.ActivityDetailBinding
-import com.pmatuki.wowpapers.remote.download.ImageDownloadService
 import com.pmatuki.wowpapers.view.extension.showToast
 import com.pmatuki.wowpapers.view.model.Wallpaper
 
@@ -37,9 +35,7 @@ class DetailActivity : AppCompatActivity() {
 
     private fun bindViewModel() {
         viewModel = ViewModelProvider(
-            this, DetailViewModelFactory(
-                ImageDownloadService(applicationContext), WallpaperService(applicationContext)
-            )
+            this, DetailViewModelFactory()
         ).get(DetailViewModel::class.java)
 
         viewModel.state.observe(this, { state ->

--- a/app/src/main/java/com/pmatuki/wowpapers/view/detail/DetailViewModelFactory.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/view/detail/DetailViewModelFactory.kt
@@ -4,12 +4,19 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.pmatuki.wowpapers.core.WallpaperService
 import com.pmatuki.wowpapers.remote.download.ImageDownloadService
+import com.pmatuki.wowpapers.view.di.DetailViewModelScope
+import javax.inject.Inject
 
-class DetailViewModelFactory(
-    private val imageDownloadService: ImageDownloadService,
-    private val wallpaperService: WallpaperService
-) : ViewModelProvider.Factory {
+class DetailViewModelFactory() : ViewModelProvider.Factory {
+
+    @Inject
+    lateinit var imageDownloadService: ImageDownloadService
+
+    @Inject
+    lateinit var wallpaperService: WallpaperService
+
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        DetailViewModelScope.scope.inject(this)
         return DetailViewModel(imageDownloadService, wallpaperService) as T
     }
 }

--- a/app/src/main/java/com/pmatuki/wowpapers/view/di/ToothpickScopes.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/view/di/ToothpickScopes.kt
@@ -1,0 +1,38 @@
+package com.pmatuki.wowpapers.view.di
+
+import com.pmatuki.wowpapers.WowpaperApplication
+import com.pmatuki.wowpapers.core.WallpaperService
+import com.pmatuki.wowpapers.remote.WallpaperDataSource
+import com.pmatuki.wowpapers.remote.download.ImageDownloadService
+import com.pmatuki.wowpapers.view.mapper.WallpaperMapper
+import toothpick.Scope
+import toothpick.config.Module
+import toothpick.ktp.KTP
+import toothpick.ktp.binding.bind
+
+object WallpaperListViewModelScope {
+    val scope: Scope =
+        KTP.openScope(WowpaperApplication.APP_SCOPE)
+            .openSubScope(WallpaperListViewModelScope)
+            .installModules(WallpaperListViewModule)
+}
+
+object WallpaperListViewModule : Module() {
+    init {
+        bind<WallpaperDataSource>()
+        bind<WallpaperMapper>()
+    }
+}
+
+object DetailViewModelScope {
+    val scope: Scope = KTP.openScope(WowpaperApplication.APP_SCOPE)
+        .openSubScope(DetailViewModelScope)
+        .installModules(DetailViewModelModule)
+}
+
+object DetailViewModelModule : Module() {
+    init {
+        bind<ImageDownloadService>()
+        bind<WallpaperService>()
+    }
+}

--- a/app/src/main/java/com/pmatuki/wowpapers/view/list/ListActivity.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/view/list/ListActivity.kt
@@ -7,11 +7,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.pmatuki.wowpapers.R
 import com.pmatuki.wowpapers.databinding.ActivityMainBinding
-import com.pmatuki.wowpapers.remote.WallpaperDataSource
-import com.pmatuki.wowpapers.remote.api.WallhavenService
 import com.pmatuki.wowpapers.view.detail.DetailActivity
 import com.pmatuki.wowpapers.view.extension.showToast
-import com.pmatuki.wowpapers.view.mapper.WallpaperMapper
 import com.pmatuki.wowpapers.view.model.Wallpaper
 
 class ListActivity : AppCompatActivity(), WallpaperItemClickListener {
@@ -34,9 +31,8 @@ class ListActivity : AppCompatActivity(), WallpaperItemClickListener {
 
     private fun bindViewModel() {
         viewModel = ViewModelProvider(
-            this, WallpaperListViewModelFactory(
-                WallpaperDataSource(WallhavenService()), WallpaperMapper()
-            )
+            this,
+            WallpaperListViewModelFactory()
         ).get(WallpaperListViewModel::class.java)
 
         viewModel.state.observe(this, { state ->

--- a/app/src/main/java/com/pmatuki/wowpapers/view/list/WallpaperListViewModelFactory.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/view/list/WallpaperListViewModelFactory.kt
@@ -3,14 +3,20 @@ package com.pmatuki.wowpapers.view.list
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.pmatuki.wowpapers.remote.WallpaperDataSource
+import com.pmatuki.wowpapers.view.di.WallpaperListViewModelScope
 import com.pmatuki.wowpapers.view.mapper.WallpaperMapper
+import javax.inject.Inject
 
-class WallpaperListViewModelFactory(
-    private val wallpaperDataSource: WallpaperDataSource,
-    private val wallpaperMapper: WallpaperMapper
-) : ViewModelProvider.Factory {
+class WallpaperListViewModelFactory() : ViewModelProvider.Factory {
+
+    @Inject
+    lateinit var wallpaperDataSource: WallpaperDataSource
+
+    @Inject
+    lateinit var wallpaperMapper: WallpaperMapper
 
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        WallpaperListViewModelScope.scope.inject(this)
         return WallpaperListViewModel(wallpaperDataSource, wallpaperMapper) as T
     }
 

--- a/app/src/main/java/com/pmatuki/wowpapers/view/mapper/WallpaperMapper.kt
+++ b/app/src/main/java/com/pmatuki/wowpapers/view/mapper/WallpaperMapper.kt
@@ -1,10 +1,12 @@
 package com.pmatuki.wowpapers.view.mapper
 
+import toothpick.InjectConstructor
 import java.net.URL
 import javax.inject.Inject
 import com.pmatuki.wowpapers.view.model.Wallpaper as ViewWallpaper
 import com.pmatuki.wowpapers.remote.model.Wallpaper as RemoteWallpaper
 
+@InjectConstructor
 class WallpaperMapper {
 
     fun toView(wallpaper: RemoteWallpaper): ViewWallpaper =


### PR DESCRIPTION
- Now using KTP for Toothpick
- Now subclassing ViewModelFactory and injecting them with dependencies needed to build ViewModel.
This avoids having to reference / instance dependency classes on the Activities.